### PR TITLE
[GPII-3868]:  Set Metadata-Flavor header in all SA metadata handlers

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,8 @@ const (
 	defaultMetadataProxyAddress = "127.0.0.1:988"
 	defaultEnableMetadataProxy  = false
 	defaultNamespaceKey         = "accounts.google.com/allowed-service-accounts"
+	defaultFlavorHeaderName     = "Metadata-Flavor"
+	defaultFlavorHeaderValue    = "Google"
 )
 
 // Server encapsulates all of the parameters necessary for starting up
@@ -221,6 +223,7 @@ func (s *Server) serviceAccountsHandler(logger *log.Entry, w http.ResponseWriter
 		return
 	}
 
+	w.Header().Set(defaultFlavorHeaderName, defaultFlavorHeaderValue)
 	write(logger, w, fmt.Sprintf("%s/\n%s/", serviceAccountMapping.ServiceAccount, "default"))
 }
 
@@ -245,6 +248,7 @@ func (s *Server) serviceAccountTokenHandler(logger *log.Entry, w http.ResponseWr
 		return
 	}
 
+	w.Header().Set(defaultFlavorHeaderName, defaultFlavorHeaderValue)
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(credentials); err != nil {
 		logger.Errorf("Error sending json %+v", err)
@@ -272,11 +276,13 @@ func (s *Server) serviceAccountIdentityHandler(logger *log.Entry, w http.Respons
 		return
 	}
 
+	w.Header().Set(defaultFlavorHeaderName, defaultFlavorHeaderValue)
 	write(logger, w, credentials)
 }
 
 func (s *Server) serviceAccountScopesHandler(logger *log.Entry, w http.ResponseWriter, r *http.Request) {
 	if serviceAccountMappingResult, err := s.validateServiceAccountRequest(logger, w, r); err == nil {
+		w.Header().Set(defaultFlavorHeaderName, defaultFlavorHeaderValue)
 		for _, scope := range serviceAccountMappingResult.Scopes {
 			write(logger, w, scope)
 		}
@@ -285,12 +291,14 @@ func (s *Server) serviceAccountScopesHandler(logger *log.Entry, w http.ResponseW
 
 func (s *Server) serviceAccountAliasesHandler(logger *log.Entry, w http.ResponseWriter, r *http.Request) {
 	if _, err := s.validateServiceAccountRequest(logger, w, r); err == nil {
+		w.Header().Set(defaultFlavorHeaderName, defaultFlavorHeaderValue)
 		write(logger, w, mux.Vars(r)["serviceAccount"])
 	}
 }
 
 func (s *Server) serviceAccountEmailHandler(logger *log.Entry, w http.ResponseWriter, r *http.Request) {
 	if serviceAccountMappingResult, err := s.validateServiceAccountRequest(logger, w, r); err == nil {
+		w.Header().Set(defaultFlavorHeaderName, defaultFlavorHeaderValue)
 		write(logger, w, serviceAccountMappingResult.ServiceAccount)
 	}
 }
@@ -305,6 +313,7 @@ func (s *Server) serviceAccountHandler(logger *log.Entry, w http.ResponseWriter,
 				write(logger, w, fmt.Sprintf("%s\n", path))
 			}
 		} else {
+			w.Header().Set(defaultFlavorHeaderName, defaultFlavorHeaderValue)
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(&ServiceAccount{
 				Aliases: []string{mux.Vars(r)["serviceAccount"]},


### PR DESCRIPTION
This PR adds missing `Metadata-Flavor` header to all direct metadata responses (not debug or reverse proxied) to make `gcp-metadata` and other libraries that expect that header from metadata  API happy.

This repo was archived, and  [docker-image-service-account-assigner](https://github.com/gpii-ops/docker-image-service-account-assigner/blob/master/Dockerfile#L4-L5) uses upstream repo pinned to specific commit.
I unarchived it – there is a slight drift from upstream, therefore there are additional commits listed in this PR.
I think we should solve this separately so they can disappear.

I'll propose my changes to upstream and open PR for `docker-image-service-account-assigner` once they are reviewed.